### PR TITLE
Print version number on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ RELEASE_VERSION :=	"v1.2.0"
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS	= -g -O2 -Wall $(MACHDEP) $(INCLUDE)
+CFLAGS	= -g -O2 -Wall $(MACHDEP) $(INCLUDE) -DPROGRAM_VERSION=\"$(RELEASE_VERSION)\"
 CXXFLAGS	=	$(CFLAGS)
 
 LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map

--- a/source/ntp.h
+++ b/source/ntp.h
@@ -25,7 +25,6 @@
 
 // some definitions required to use wplaat's networking library html.[hc]
 #define PROGRAM_NAME		"sntp"
-#define PROGRAM_VERSION		"1.1.0"
 #define MAX_LEN				1024
 #define TRACE_FILENAME		NTP_HOME "/sntp.trc"
 #define URL_TOKEN			"\"gmtOffset\": "

--- a/source/sntp.c
+++ b/source/sntp.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
 
 	__lwp_queue_init_empty(&queue);
 
-	printf ("\nNTP time synchronizer\n");
+	printf ("\nNTP time synchronizer %s %s\n", PROGRAM_NAME, PROGRAM_VERSION);
 
 	ret = SYSCONF_Init();
 	if (ret < 0) {
@@ -432,7 +432,7 @@ void get_tz_offset() {
 	if(tcp_state == TCP_IDLE)
 	{
 		gmt_offset = atoi(tcp_get_version());
-		printf("Found GMT offset online of %d\n", gmt_offset);
+		printf("Found GMT offset online of %d seconds\n", gmt_offset);
 	}
 	else
 	{


### PR DESCRIPTION
Tried to add the feature that launches an app of your choice like wiiflow after exiting sntp but it worked once or twice then crashed the Wii so gave up.

Kept this code that prints the sntp version number from the Makefile on startup and deletes the out of date version number from ntp.h.

Also added the word _seconds_ when printing GMT offset from the online API. A number without units is meaningless.